### PR TITLE
Update HomesteadBehavior.cs

### DIFF
--- a/HomesteadBehavior.cs
+++ b/HomesteadBehavior.cs
@@ -279,7 +279,7 @@ namespace Homesteads {
 
             homesteadParty.ActualClan = Hero.MainHero.Clan;
             homesteadParty.ShouldJoinPlayerBattles = true;
-            homesteadParty.Party.Visuals.SetMapIconAsDirty(); //SetVisualAsDirty();
+            homesteadParty.Party.SetVisualAsDirty(); // homesteadParty.Party.Visuals.SetMapIconAsDirty(); //SetVisualAsDirty();
 
             HomesteadMobileParties[homesteadParty] = component;
 


### PR DESCRIPTION
The party object no longer has a Visuals sub-object, directly use the void method to "dirty" it.